### PR TITLE
Upgrading to 5.8.X

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.x|5.1.x|5.2.x|5.3.x|5.4.x|5.5.X|5.6.X|5.7.X|5.8.X",
-        "illuminate/filesystem": "5.0.x|5.1.x|5.2.x|5.3.x|5.4.x|5.5.X|5.6.X|5.7.X|5.8.X",
+        "illuminate/support": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X",
+        "illuminate/filesystem": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X",
         "symfony/process": "v2.x|v3.x|v4.x"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.4.0",
-        "illuminate/support": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X|6.x",
-        "illuminate/filesystem": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X|6.x",
-        "symfony/process": "^2.0"
+        "php": "^7.3",
+        "illuminate/support": "^6.0",
+        "illuminate/filesystem": "^6.0",
+        "symfony/process": "^4.3.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X",
-        "illuminate/filesystem": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X",
+        "illuminate/support": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X|6.x",
+        "illuminate/filesystem": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X|6.x",
         "symfony/process": "v2.x|v3.x|v4.x"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^7.3",
-        "illuminate/support": "^6.0",
-        "illuminate/filesystem": "^6.0",
+        "illuminate/support": "^7.0",
+        "illuminate/filesystem": "^7.0",
         "symfony/process": "^4.3.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.3",
+        "php": "^7.4",
         "illuminate/support": "^7.0",
         "illuminate/filesystem": "^7.0",
         "symfony/process": "^5.0"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.4.0",
         "illuminate/support": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X|6.x",
         "illuminate/filesystem": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X|6.x",
-        "symfony/process": "v2.x|v3.x|v4.x"
+        "symfony/process": "^2.x"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.4.0",
         "illuminate/support": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X|6.x",
         "illuminate/filesystem": "5.4.x|5.5.X|5.6.X|5.7.X|5.8.X|6.x",
-        "symfony/process": "^2.x"
+        "symfony/process": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.x|5.1.x|5.2.x|5.3.x|5.4.x|5.5.X|5.6.X|5.7.X",
-        "illuminate/filesystem": "5.0.x|5.1.x|5.2.x|5.3.x|5.4.x|5.5.X|5.6.X|5.7.X",
+        "illuminate/support": "5.0.x|5.1.x|5.2.x|5.3.x|5.4.x|5.5.X|5.6.X|5.7.X|5.8.X",
+        "illuminate/filesystem": "5.0.x|5.1.x|5.2.x|5.3.x|5.4.x|5.5.X|5.6.X|5.7.X|5.8.X",
         "symfony/process": "v2.x|v3.x|v4.x"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.3",
         "illuminate/support": "^7.0",
         "illuminate/filesystem": "^7.0",
-        "symfony/process": "^4.3.4"
+        "symfony/process": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Techsemicolon/Latex.php
+++ b/src/Techsemicolon/Latex.php
@@ -196,7 +196,7 @@ class Latex
 
         $fileMoved = \File::move($pdfPath, $location);
 
-        \Event::fire(new LatexPdfWasGenerated($location, 'savepdf', $this->metadata));
+        \Event::dispatch(new LatexPdfWasGenerated($location, 'savepdf', $this->metadata));
 
         return $fileMoved;
     }
@@ -219,7 +219,7 @@ class Latex
             $fileName = basename($pdfPath);
         }
 
-        \Event::fire(new LatexPdfWasGenerated($fileName, 'download', $this->metadata));
+        \Event::dispatch(new LatexPdfWasGenerated($fileName, 'download', $this->metadata));
 
         return \Response::download($pdfPath, $fileName, [
               'Content-Type' => 'application/pdf',
@@ -248,7 +248,7 @@ class Latex
 
         if (!$process->isSuccessful()) {
         	
-            \Event::fire(new LatexPdfFailed($fileName, 'download', $this->metadata));
+            \Event::dispatch(new LatexPdfFailed($fileName, 'download', $this->metadata));
         	$this->parseError($tmpfname, $process);
         }
 

--- a/src/Techsemicolon/Latex.php
+++ b/src/Techsemicolon/Latex.php
@@ -83,7 +83,7 @@ class Latex
      * 
      * @param  string $binPath
      * 
-     * @return void
+     * @return Latex
      */
     public function binPath($binPath){
 
@@ -100,7 +100,7 @@ class Latex
      * 
      * @param  string $nameInsideZip
      * 
-     * @return void
+     * @return Latex
      */
     public function setName($nameInsideZip){
 
@@ -127,7 +127,7 @@ class Latex
      * 
      * @param  array $data
      * 
-     * @return void
+     * @return Latex
      */
     public function with($data){
 

--- a/src/Techsemicolon/Latex.php
+++ b/src/Techsemicolon/Latex.php
@@ -145,7 +145,7 @@ class Latex
 
         $this->isRaw = true;
 
-        $process = new Process("which pdflatex");
+        $process = new Process(["which", "pdflatex"]);
         $process->run();
 
         if (!$process->isSuccessful()) {
@@ -241,7 +241,7 @@ class Latex
         \File::put($tmpfname, $this->renderedTex);
 
         $program    = $this->binPath ? $this->binPath : 'pdflatex';
-        $cmd        = "$program -output-directory $tmpDir $tmpfname";
+        $cmd        = [$program, "-output-directory", $tmpDir, $tmpfname];
         
         $process    = new Process($cmd);
         $process->run();

--- a/src/Techsemicolon/LatexCollection.php
+++ b/src/Techsemicolon/LatexCollection.php
@@ -2,7 +2,6 @@
 
 namespace Techsemicolon;
 
-use Symfony\Component\Process\Process;
 use Techsemicolon\Latex;
 use Techsemicolon\LatextEmptyCollectionException;
 use Techsemicolon\LatextException;


### PR DESCRIPTION
I changed the code to work with 5.8.X

Since Laravel 5.4 deprecated the Event::fire method, introduced Event::dispatch and 5.8 removed Event::dispatch this only works for installations with 5.4 or newer.

Readding compatibility for prior 5.4 versions should be easily possible by check which Laravel version is used. In my opinion differentiate the compatibility between package versions would feel more like "the way to do"

fixes #2 